### PR TITLE
Restructure oauth mock data and re-record vcr

### DIFF
--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -11,10 +11,10 @@ class UserService < BaseService
   end
 
   def self.create_user(data)
-    response = conn.post "/api/v1/users/register", {
+    response = conn.post("/api/v1/users/register", {
       email: data[:email], 
       username: data[:name]
-    }.to_json, "Content-Type" => "application/json"
+    }.to_json, "Content-Type" => "application/json")
     get_json(response)
   end
 end

--- a/spec/facades/user_facade_spec.rb
+++ b/spec/facades/user_facade_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe UserFacade do 
   it 'creates poro for create user', :vcr do 
-    info = {username: "Bob", email: "bob@email.com"}
+    info = {name: "Bob", email: "bob@email.com"}
     user = UserFacade.find_create_user(info)
 
     expect(user).to be_a(User)

--- a/spec/fixtures/vcr_cassettes/BuildingFacade/creates_location_from_search.yml
+++ b/spec/fixtures/vcr_cassettes/BuildingFacade/creates_location_from_search.yml
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - Cowboy
       Date:
-      - Fri, 29 Jul 2022 23:05:31 GMT
+      - Sat, 30 Jul 2022 18:04:57 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -31,9 +31,9 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 8d5ceaa4-fd68-43c9-be2f-d7b7ad12f65b
+      - 7596af8b-86c4-4fac-9d3b-179c2a524abd
       X-Runtime:
-      - '0.058412'
+      - '0.060078'
       Transfer-Encoding:
       - chunked
       Via:
@@ -41,5 +41,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"street":"1623 Market St","county":"Denver","city":"Denver","state":"CO","zipcode":"80202"}'
-  recorded_at: Fri, 29 Jul 2022 23:05:32 GMT
+  recorded_at: Sat, 30 Jul 2022 18:04:58 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/Building_service/establishes_connection_with_Building/search_API.yml
+++ b/spec/fixtures/vcr_cassettes/Building_service/establishes_connection_with_Building/search_API.yml
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - Cowboy
       Date:
-      - Fri, 29 Jul 2022 23:05:33 GMT
+      - Sat, 30 Jul 2022 18:05:00 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -31,9 +31,9 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - c0edc0e8-880d-451a-a5f4-6d1cad3d8f1b
+      - 74d1acf9-efaf-49c8-8533-f129d718164c
       X-Runtime:
-      - '0.056696'
+      - '0.046063'
       Transfer-Encoding:
       - chunked
       Via:
@@ -41,5 +41,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"street":"1623 Market St","county":"Denver","city":"Denver","state":"CO","zipcode":"80202"}'
-  recorded_at: Fri, 29 Jul 2022 23:05:34 GMT
+  recorded_at: Sat, 30 Jul 2022 18:05:00 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/Landing_page/has_a_link_to_create_an_account.yml
+++ b/spec/fixtures/vcr_cassettes/Landing_page/has_a_link_to_create_an_account.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://history-maps-be.herokuapp.com/api/v1/users/register
     body:
       encoding: UTF-8
-      string: '{"email":"vballmatt44@gmail.com","username":null}'
+      string: '{"email":"john.doe@example.com","username":"John Doe"}'
     headers:
       User-Agent:
       - Faraday v2.3.0
@@ -17,27 +17,32 @@ http_interactions:
       - "*/*"
   response:
     status:
-      code: 422
-      message: Unprocessable Entity
+      code: 201
+      message: Created
     headers:
       Server:
       - Cowboy
       Date:
-      - Fri, 29 Jul 2022 23:07:15 GMT
+      - Sat, 30 Jul 2022 18:04:58 GMT
       Connection:
       - keep-alive
       Content-Type:
-      - text/html; charset=UTF-8
+      - application/json; charset=utf-8
+      Etag:
+      - W/"ab2589cd1611667ac91a0bb1c7c8a8b4"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 96836ba0-dd35-42d8-847a-e1f8fd4dcd67
+      - ac2f8b62-c827-4824-aa3f-dc36a1b95b85
       X-Runtime:
-      - '0.013184'
-      Content-Length:
-      - '0'
+      - '0.003511'
+      Transfer-Encoding:
+      - chunked
       Via:
       - 1.1 vegur
     body:
       encoding: UTF-8
-      string: ''
-  recorded_at: Fri, 29 Jul 2022 23:07:16 GMT
+      string: '{"data":{"id":"5","type":"user","attributes":{"email":"john.doe@example.com","username":"John
+        Doe"}}}'
+  recorded_at: Sat, 30 Jul 2022 18:04:59 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/Landing_page/search_location/can_have_all_the_buttons.yml
+++ b/spec/fixtures/vcr_cassettes/Landing_page/search_location/can_have_all_the_buttons.yml
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - Cowboy
       Date:
-      - Fri, 29 Jul 2022 23:05:33 GMT
+      - Sat, 30 Jul 2022 18:04:59 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -31,9 +31,9 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - d6a381d3-b381-4fcf-a6b1-3d5851d93424
+      - 67e8e4b2-2f34-48eb-ac90-2b9d8d7b2854
       X-Runtime:
-      - '0.051551'
+      - '0.057808'
       Transfer-Encoding:
       - chunked
       Via:
@@ -41,5 +41,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"street":"1623 Market St","county":"Denver","city":"Denver","state":"CO","zipcode":"80202"}'
-  recorded_at: Fri, 29 Jul 2022 23:05:34 GMT
+  recorded_at: Sat, 30 Jul 2022 18:05:00 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/Landing_page/search_location/can_search_for_a_location.yml
+++ b/spec/fixtures/vcr_cassettes/Landing_page/search_location/can_search_for_a_location.yml
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - Cowboy
       Date:
-      - Fri, 29 Jul 2022 23:05:32 GMT
+      - Sat, 30 Jul 2022 18:04:59 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -31,9 +31,9 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 955b651f-d2fe-4828-95cc-5f577be15c48
+      - 6aa559de-7f62-4243-84f9-dd29fd528580
       X-Runtime:
-      - '0.058290'
+      - '0.047753'
       Transfer-Encoding:
       - chunked
       Via:
@@ -41,5 +41,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"street":"1623 Market St","county":"Denver","city":"Denver","state":"CO","zipcode":"80202"}'
-  recorded_at: Fri, 29 Jul 2022 23:05:33 GMT
+  recorded_at: Sat, 30 Jul 2022 18:04:59 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/User/exists_and_has_attributes.yml
+++ b/spec/fixtures/vcr_cassettes/User/exists_and_has_attributes.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - Cowboy
       Date:
-      - Fri, 29 Jul 2022 23:05:33 GMT
+      - Sat, 30 Jul 2022 18:05:00 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -33,9 +33,9 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - b5f5e0d8-caf1-42db-8e11-cebbaa28bf2a
+      - ac2818d2-cae1-4276-ad67-3c2d9a5992d7
       X-Runtime:
-      - '0.003499'
+      - '0.003566'
       Transfer-Encoding:
       - chunked
       Via:
@@ -43,5 +43,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"data":{"id":"4","type":"user","attributes":{"email":"bob@email.com","username":"Bob"}}}'
-  recorded_at: Fri, 29 Jul 2022 23:05:34 GMT
+  recorded_at: Sat, 30 Jul 2022 18:05:00 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/UserFacade/creates_poro_for_all_users.yml
+++ b/spec/fixtures/vcr_cassettes/UserFacade/creates_poro_for_all_users.yml
@@ -21,19 +21,19 @@ http_interactions:
       Server:
       - Cowboy
       Date:
-      - Fri, 29 Jul 2022 23:05:32 GMT
+      - Sat, 30 Jul 2022 18:04:58 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"4dcaa668fa6abbcd9178fcb45c9b5b88"
+      - W/"eb84029a7e84835ae10be52b6dab68ec"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 953796cd-8c88-4104-b9d2-24f38c64b561
+      - 56f1e8dc-24ea-47aa-924b-0981d965e755
       X-Runtime:
-      - '0.003280'
+      - '0.003240'
       Transfer-Encoding:
       - chunked
       Via:
@@ -42,6 +42,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"data":[{"id":"1","type":"user","attributes":{"email":"smallgirly111@gmail.com1","username":"small
         girl111"}},{"id":"2","type":"user","attributes":{"email":"someone@email.com","username":"someone"}},{"id":"3","type":"user","attributes":{"email":"smallgirly111@gmail.com11","username":"small
-        girl11"}},{"id":"4","type":"user","attributes":{"email":"bob@email.com","username":"Bob"}}]}'
-  recorded_at: Fri, 29 Jul 2022 23:05:32 GMT
+        girl11"}},{"id":"4","type":"user","attributes":{"email":"bob@email.com","username":"Bob"}},{"id":"5","type":"user","attributes":{"email":"john.doe@example.com","username":"John
+        Doe"}}]}'
+  recorded_at: Sat, 30 Jul 2022 18:04:58 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/UserFacade/creates_poro_for_create_user.yml
+++ b/spec/fixtures/vcr_cassettes/UserFacade/creates_poro_for_create_user.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - Cowboy
       Date:
-      - Fri, 29 Jul 2022 23:05:31 GMT
+      - Sat, 30 Jul 2022 18:04:57 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -33,9 +33,9 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 36fb0f25-a456-4001-a898-0c279d668baa
+      - 4e3ddc41-73df-41cb-9544-909fc45d5708
       X-Runtime:
-      - '0.003720'
+      - '0.003705'
       Transfer-Encoding:
       - chunked
       Via:
@@ -43,5 +43,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"data":{"id":"4","type":"user","attributes":{"email":"bob@email.com","username":"Bob"}}}'
-  recorded_at: Fri, 29 Jul 2022 23:05:32 GMT
+  recorded_at: Sat, 30 Jul 2022 18:04:58 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/UserFacade/creates_poro_for_one_user.yml
+++ b/spec/fixtures/vcr_cassettes/UserFacade/creates_poro_for_one_user.yml
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - Cowboy
       Date:
-      - Fri, 29 Jul 2022 23:05:32 GMT
+      - Sat, 30 Jul 2022 18:04:58 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -31,9 +31,9 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 1b6f596d-34b0-45ea-b412-64e205573652
+      - 8f22e0d4-1a92-4ab4-b371-c8df679a4da6
       X-Runtime:
-      - '0.003585'
+      - '0.004051'
       Transfer-Encoding:
       - chunked
       Via:
@@ -41,5 +41,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"data":{"id":"2","type":"user","attributes":{"email":"someone@email.com","username":"someone"}}}'
-  recorded_at: Fri, 29 Jul 2022 23:05:33 GMT
+  recorded_at: Sat, 30 Jul 2022 18:04:59 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/User_service/establishes_connection_to_create_new_user.yml
+++ b/spec/fixtures/vcr_cassettes/User_service/establishes_connection_to_create_new_user.yml
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - Cowboy
       Date:
-      - Fri, 29 Jul 2022 23:05:34 GMT
+      - Sat, 30 Jul 2022 18:05:00 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -33,9 +33,9 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 257b4ca4-44ac-426a-8861-9aa048c20fa4
+      - fe774101-e5f0-4822-9302-85730778c9ea
       X-Runtime:
-      - '0.003478'
+      - '0.005004'
       Transfer-Encoding:
       - chunked
       Via:
@@ -43,5 +43,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"data":{"id":"2","type":"user","attributes":{"email":"someone@email.com","username":"someone"}}}'
-  recorded_at: Fri, 29 Jul 2022 23:05:35 GMT
+  recorded_at: Sat, 30 Jul 2022 18:05:01 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/User_service/establishes_connection_to_return_one_user.yml
+++ b/spec/fixtures/vcr_cassettes/User_service/establishes_connection_to_return_one_user.yml
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - Cowboy
       Date:
-      - Fri, 29 Jul 2022 23:05:34 GMT
+      - Sat, 30 Jul 2022 18:05:01 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -31,9 +31,9 @@ http_interactions:
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 1413b77a-ef64-42b9-bbdb-2b479dbcde14
+      - 2ad8265b-ddee-484a-bece-f34291c45d22
       X-Runtime:
-      - '0.003195'
+      - '0.003921'
       Transfer-Encoding:
       - chunked
       Via:
@@ -42,5 +42,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"data":{"id":"3","type":"user","attributes":{"email":"smallgirly111@gmail.com11","username":"small
         girl11"}}}'
-  recorded_at: Fri, 29 Jul 2022 23:05:35 GMT
+  recorded_at: Sat, 30 Jul 2022 18:05:01 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/User_service/establishes_connection_with_User_API.yml
+++ b/spec/fixtures/vcr_cassettes/User_service/establishes_connection_with_User_API.yml
@@ -21,19 +21,19 @@ http_interactions:
       Server:
       - Cowboy
       Date:
-      - Fri, 29 Jul 2022 23:05:34 GMT
+      - Sat, 30 Jul 2022 18:05:01 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - W/"4dcaa668fa6abbcd9178fcb45c9b5b88"
+      - W/"eb84029a7e84835ae10be52b6dab68ec"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - e1bafde7-7b4b-425a-987f-b337a9fbc49f
+      - 54d13e3b-cfb5-4e36-bd36-4f0c07e1b695
       X-Runtime:
-      - '0.003422'
+      - '0.003610'
       Transfer-Encoding:
       - chunked
       Via:
@@ -42,6 +42,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"data":[{"id":"1","type":"user","attributes":{"email":"smallgirly111@gmail.com1","username":"small
         girl111"}},{"id":"2","type":"user","attributes":{"email":"someone@email.com","username":"someone"}},{"id":"3","type":"user","attributes":{"email":"smallgirly111@gmail.com11","username":"small
-        girl11"}},{"id":"4","type":"user","attributes":{"email":"bob@email.com","username":"Bob"}}]}'
-  recorded_at: Fri, 29 Jul 2022 23:05:34 GMT
+        girl11"}},{"id":"4","type":"user","attributes":{"email":"bob@email.com","username":"Bob"}},{"id":"5","type":"user","attributes":{"email":"john.doe@example.com","username":"John
+        Doe"}}]}'
+  recorded_at: Sat, 30 Jul 2022 18:05:01 GMT
 recorded_with: VCR 6.1.0

--- a/spec/poros/user_spec.rb
+++ b/spec/poros/user_spec.rb
@@ -2,10 +2,9 @@ require 'rails_helper'
 
 RSpec.describe User do 
   it 'exists and has attributes', :vcr do 
-    info = {username: "Bob", email: "bob@email.com"}
+    info = {name: "Bob", email: "bob@email.com"}
     user = UserFacade.find_create_user(info)
 
-    # expect(user.id).to eq()
     expect(user.username).to eq("Bob")
     expect(user.email).to eq("bob@email.com")
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -73,20 +73,51 @@ end
 
 OmniAuth.config.test_mode = true
 OmniAuth.config.silence_get_warning = true
-OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
-  provider: "google_oauth2",
-  uid: "12345678910",
-  info: {
-    name: "Matt Deming",
-   email: "vballmatt44@gmail.com",
- },
- credentials: {
-   token:
-    "abcdefg12355",
-   refresh_token:
-    "abcdefg12345",
-   expires_at: DateTime.now,
+OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new(
+{
+  :provider => "google_oauth2",
+  :uid => "123456789",
+  :info => {
+    :name => "John Doe",
+    :email => "john.doe@example.com",
+    :first_name => "John",
+    :last_name => "Doe",
+    :image => "https://lh3.googleusercontent.com/url/photo.jpg"
+  },
+  :credentials => {
+      :token => "token",
+      :refresh_token => "another_token",
+      :expires_at => 1354920555,
+      :expires => true
+  },
+  :extra => {
+    :raw_info => {
+      :sub => "123456789",
+      :email => "john.doe@example.com",
+      :email_verified => true,
+      :name => "John Doe",
+      :given_name => "John",
+      :family_name => "Doe",
+      :profile => "https://plus.google.com/123456789",
+      :picture => "https://lh3.googleusercontent.com/url/photo.jpg",
+      :gender => "male",
+      :birthday => "0000-06-25",
+      :locale => "en",
+      :hd => "example.com"
+    },
+    :id_info => {
+      "iss" => "accounts.google.com",
+      "at_hash" => "HK6E_P6Dh8Y93mRNtsDB1Q",
+      "email_verified" => "true",
+      "sub" => "10769150350006150715113082367",
+      "azp" => "APP_ID",
+      "email" => "jsmith@example.com",
+      "aud" => "APP_ID",
+      "iat" => 1353601026,
+      "exp" => 1353604926,
+      "openid_id" => "https://www.google.com/accounts/o8/id?id=ABCdfdswawerSDFDsfdsfdfjdsf"
     }
+  }
 })
 #
 # Rails.application.env_config['omniauth.auth'] = OmniAuth.config.mock_auth[:google_oauth2]

--- a/spec/services/user_service_spec.rb
+++ b/spec/services/user_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "User service" do
   end
 
   it 'establishes connection to create new user', :vcr do 
-    user_data = {email: 'someone@email.com', username: 'someone'}
+    user_data = {email: 'someone@email.com', name: 'someone'}
     new_user = UserService.create_user(user_data)
 
     expect(new_user[:data]).to be_a(Hash)


### PR DESCRIPTION
## Description of Changes:

This PR restructures oauth mock data in rails helper to include entire oauth data return, and adjusts tests in User Service, Facade and Poro to mimic oauth data.  

## Put an 'X' next to all that apply

New Test: []
New Feature:[]
Bug Fix: [X]

## Before You Submit Ensure

All Tests Pass: [X]
Full Coverage: []
Runs Locally: [X]
